### PR TITLE
Updating Link in Partners Section

### DIFF
--- a/service/components/home-sections/Partners.js
+++ b/service/components/home-sections/Partners.js
@@ -29,7 +29,7 @@ export const aPartners = [
   },
   {
     image: 'assets/partners/09_swissmade_software_logo.png',
-    url: 'https://www.swissmadesoftware.org',
+    url: 'https://www.swissmadesoftware.org/home.html',
   },
   { url: 'https://blockark.io/', image: 'assets/partners/BLOCKARK-LOGO.png' },
   {


### PR DESCRIPTION
This link used to result in a timeout for crawling bots and had negative implications on SEO.