### PR TITLE
Changed missing link on /token page.

### DIFF
--- a/service/components/atoms/modal.js
+++ b/service/components/atoms/modal.js
@@ -23,7 +23,7 @@ const Modal = forwardRef(({ showModal, setShowModal, url }, ref) => {
               </div>
               <Button
                 className="btn-modal"
-                target="_blank"
+                target="https://app.uniswap.org/#/swap?outputCurrency=0xf5581dfefd8fb0e4aec526be659cfab1f8c781da&chain=mainnet"
                 content={t('home:modal.btnIAgree')}
                 onClick={() => setShowModal(false)}
                 to={url}

--- a/service/components/atoms/modal.js
+++ b/service/components/atoms/modal.js
@@ -23,10 +23,10 @@ const Modal = forwardRef(({ showModal, setShowModal, url }, ref) => {
               </div>
               <Button
                 className="btn-modal"
-                target="https://app.uniswap.org/#/swap?outputCurrency=0xf5581dfefd8fb0e4aec526be659cfab1f8c781da&chain=mainnet"
+                target="_blank"
                 content={t('home:modal.btnIAgree')}
                 onClick={() => setShowModal(false)}
-                to={url}
+                to="https://app.uniswap.org/#/swap?outputCurrency=0xf5581dfefd8fb0e4aec526be659cfab1f8c781da&chain=mainnet"
               />
             </div>
           </div>


### PR DESCRIPTION
The "Get HOPR" link on the first section of the /token page wasn't redirecting to Uniswap as it should. While inspecting the html I found that the button referred to "_blank", which I changed to the Uniswap Link.