### PR TITLE
Fix spelling mistake on /technology

### DIFF
--- a/service/locales/en/tech.json
+++ b/service/locales/en/tech.json
@@ -21,7 +21,7 @@
     "title": "Open Source Support"
   },
   "second": {
-    "paragraphA": "The HOPR protocol provides network-level and metadata privacy for every kind of data exchange. A mixnet protects the identity of both sender and recipe ent by routing data via multiple intermediate relay hops that mix traffic.",
+    "paragraphA": "The HOPR protocol provides network-level and metadata privacy for every kind of data exchange. A mixnet protects the identity of both sender and recipient by routing data via multiple intermediate relay hops that mix traffic.",
     "paragraphB": "Payments are handled via probabilistic micropayments, our custom layer-2 scaling solution on top of the Ethereum blockchain.",
     "paragraphC": "Relay mix nodes are rewarded for their work in HOPR tokens. Our proof-of-relay mechanism protects everyone from dishonest behaviour.",
     "paragraphD": "HOPR thus provides economic incentives to run a global privacy network sustainably - and at scale - without compromising privacy.",


### PR DESCRIPTION
Fixed small spelling mistake "recipe ent" to "recipient".